### PR TITLE
Handle raw inbound email forwarding

### DIFF
--- a/api/email2email.js
+++ b/api/email2email.js
@@ -7,6 +7,17 @@ const { TextDecoder } = require('util');
 const busboy = require('busboy');
 const addrs = require("email-addresses");
 const sgMail = require('@sendgrid/mail');
+const { simpleParser } = require('mailparser');
+
+const blockedDomainPattern = /\.(buzz|guru|cyou|biz|live|co|us|today|icu|rest|bar|za\.com|ru\.com|sa\.com|click)$/i;
+
+class InboundEmailError extends Error {
+    constructor(message, statusCode = 400) {
+        super(message);
+        this.name = 'InboundEmailError';
+        this.statusCode = statusCode;
+    }
+}
 
 function parseInboundForm(req) {
     return new Promise((resolve, reject) => {
@@ -69,6 +80,34 @@ function parseInboundForm(req) {
     });
 }
 
+function readRequestBody(req) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('error', reject);
+        req.on('end', () => resolve(Buffer.concat(chunks)));
+    });
+}
+
+function isMultipartRequest(req) {
+    const contentType = req.headers && (req.headers['content-type'] || req.headers['Content-Type']);
+    return Boolean(contentType && /multipart\/form-data/i.test(contentType));
+}
+
+async function parseInboundRequest(req) {
+    if (isMultipartRequest(req)) {
+        return parseInboundForm(req);
+    }
+
+    return {
+        body: {
+            email: await readRequestBody(req),
+        },
+        files: [],
+    };
+}
+
 function decodeFormValue(value, charset) {
     if (value === undefined || value === null) {
         return '';
@@ -90,12 +129,117 @@ function parseJsonFormValue(value) {
         return {};
     }
 
-    return JSON.parse(decodeFormValue(value, 'utf-8'));
+    try {
+        return JSON.parse(decodeFormValue(value, 'utf-8'));
+    } catch (error) {
+        return {};
+    }
 }
 
-module.exports = async (req, res) => { 
-    const parsedForm = await parseInboundForm(req);
+function formValueAsBuffer(value) {
+    if (Buffer.isBuffer(value)) {
+        return value;
+    }
+
+    const rawValue = Array.isArray(value) ? value[value.length - 1] : value;
+    return Buffer.from(String(rawValue || ''), 'latin1');
+}
+
+function parseOneAddress(value) {
+    if (!value) {
+        return null;
+    }
+
+    return addrs.parseOneAddress(value);
+}
+
+function parseMailparserAddress(addressObject) {
+    const addressValues = Array.isArray(addressObject)
+        ? addressObject.flatMap((entry) => entry.value || [])
+        : (addressObject && addressObject.value) || [];
+    const mailbox = addressValues.find((entry) => entry.address);
+
+    if (!mailbox) {
+        return null;
+    }
+
+    return parseOneAddress(mailbox.address);
+}
+
+function validateInboundEmail(inboundEmail) {
+    if (!inboundEmail.fromAddress || !inboundEmail.fromAddress.address) {
+        throw new InboundEmailError('Missing or invalid From address');
+    }
+
+    if (!inboundEmail.toAddress || !inboundEmail.toAddress.address) {
+        throw new InboundEmailError('Missing or invalid To address');
+    }
+}
+
+function buildFormAttachments(parsedForm, reqBody) {
+    const attachmentCount = Number.parseInt(decodeFormValue(reqBody.attachments, 'utf-8'), 10) || 0;
+
+    if (attachmentCount <= 0) {
+        return [];
+    }
+
+    const attachmentInfo = parseJsonFormValue(reqBody['attachment-info']);
+    const files = parsedForm.files || [];
+
+    return files.map((file) => {
+        const attachmentMeta = attachmentInfo[file.fieldname] || {};
+        const attachment = fs.readFileSync(file.path).toString('base64');
+
+        fs.unlink(file.path, () => {});
+
+        return {
+            content: attachment,
+            filename: attachmentMeta.filename || attachmentMeta.name || file.originalname,
+            type: attachmentMeta.type || file.mimetype,
+            disposition: 'attachment',
+        };
+    });
+}
+
+function buildRawAttachments(attachments) {
+    return (attachments || []).map((attachment) => {
+        const sendGridAttachment = {
+            content: attachment.content.toString('base64'),
+            filename: attachment.filename || 'attachment',
+            type: attachment.contentType || 'application/octet-stream',
+            disposition: attachment.contentDisposition || 'attachment',
+        };
+
+        if (attachment.contentId) {
+            sendGridAttachment.content_id = attachment.contentId.replace(/^<|>$/g, '');
+        }
+
+        return sendGridAttachment;
+    });
+}
+
+async function parseRawInboundEmail(rawEmail) {
+    const parsed = await simpleParser(formValueAsBuffer(rawEmail));
+
+    return {
+        from: parsed.from ? parsed.from.text : '',
+        to: parsed.to ? parsed.to.text : '',
+        subject: parsed.subject || '',
+        text: parsed.text || '',
+        html: typeof parsed.html === 'string' ? parsed.html : '',
+        fromAddress: parseMailparserAddress(parsed.from),
+        toAddress: parseMailparserAddress(parsed.to),
+        attachments: buildRawAttachments(parsed.attachments),
+    };
+}
+
+async function parseInboundEmail(parsedForm) {
     const reqBody = parsedForm.body;
+
+    if (reqBody.email) {
+        return parseRawInboundEmail(reqBody.email);
+    }
+
     const charsets = parseJsonFormValue(reqBody.charsets);
 
     const from = decodeFormValue(reqBody.from, charsets.from);
@@ -103,68 +247,67 @@ module.exports = async (req, res) => {
     const subject = decodeFormValue(reqBody.subject, charsets.subject);
     const body = decodeFormValue(reqBody.text, charsets.text);
     const html = decodeFormValue(reqBody.html, charsets.html);
-    const attachmentCount = Number.parseInt(decodeFormValue(reqBody.attachments, 'utf-8'), 10) || 0;
 
-    // Strip for email 
-    const fromAddress = addrs.parseOneAddress(from);
-    const toAddress = addrs.parseOneAddress(to);
+    return {
+        from: from,
+        to: to,
+        subject: subject,
+        text: body,
+        html: html,
+        fromAddress: parseOneAddress(from),
+        toAddress: parseOneAddress(to),
+        attachments: buildFormAttachments(parsedForm, reqBody),
+    };
+}
 
-    // SendGrid API
-    sgMail.setApiKey(process.env.SENDGRID_API_KEY);
-    var email = {};
-    if (attachmentCount > 0){
+function buildForwardEmail(inboundEmail) {
+    validateInboundEmail(inboundEmail);
 
-        // Create Email with attachment
-        const attachmentInfo = parseJsonFormValue(reqBody['attachment-info']);
+    const email = {
+        to: process.env.TO_EMAIL_ADDRESS,
+        from: inboundEmail.toAddress.address,
+        subject: `${inboundEmail.subject}${inboundEmail.attachments.length > 0 ? ' attach' : ''} [${inboundEmail.fromAddress.domain}]`,
+        text: inboundEmail.text || '',
+    };
 
-        let attachmentsArray = [];
-        var files = parsedForm.files;
-        if(files){
-            files.forEach(function(file){
-                const attachmentMeta = attachmentInfo[file.fieldname] || {};
-                var attachment = fs.readFileSync(file.path).toString("base64");
-                const attachmentContent = {
-                    content: attachment,
-                    filename: attachmentMeta.filename || attachmentMeta.name || file.originalname,
-                    type: attachmentMeta.type || file.mimetype,
-                    disposition: "attachment"
-                }
-                attachmentsArray.push(attachmentContent);
-            });
-        }   
-
-        //Create Email With Attachment
-        email = {
-            to: process.env.TO_EMAIL_ADDRESS,
-            from: toAddress.address,
-            subject: `${subject} attach [${fromAddress.domain}]`,
-            text: `${body}`,
-            html: `${html}`,
-            attachments: attachmentsArray,
-        };
-        
-    } else {
-        // Create Email
-        email = {
-            to: process.env.TO_EMAIL_ADDRESS,
-            from: toAddress.address,
-            subject: `${subject} [${fromAddress.domain}]`,
-            text: `${body}`,
-            html: `${html}`,
-        };
-    } 
-
-    var patt = new RegExp("\.(buzz|guru|cyou|biz|live|co|us|today|icu|rest|bar|za.com|ru.com|sa.com|click)$");
-    if (patt.test(fromAddress.domain)==false) {
-        //Send Email
-        sgMail.send(email)
-            .then(response => {
-                res.status(200).send(`Sent Email`);
-            })
-            .catch(error => {
-                res.status(500);
-            });    
-    } else {
-        res.status(200).send(`Wont Sent Email`);
+    if (inboundEmail.html) {
+        email.html = inboundEmail.html;
     }
+
+    if (inboundEmail.attachments.length > 0) {
+        email.attachments = inboundEmail.attachments;
+    }
+
+    return email;
+}
+
+async function handler(req, res) {
+    try {
+        const parsedForm = await parseInboundRequest(req);
+        const inboundEmail = await parseInboundEmail(parsedForm);
+
+        validateInboundEmail(inboundEmail);
+
+        if (blockedDomainPattern.test(inboundEmail.fromAddress.domain)) {
+            return res.status(200).send(`Wont Sent Email`);
+        }
+
+        // SendGrid API
+        sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+        await sgMail.send(buildForwardEmail(inboundEmail));
+
+        return res.status(200).send(`Sent Email`);
+    } catch (error) {
+        const statusCode = error.statusCode || 500;
+        console.error('email2email failed:', error);
+        return res.status(statusCode).send(statusCode === 500 ? 'Failed to process inbound email' : error.message);
+    }
+}
+
+module.exports = handler;
+module.exports._test = {
+    buildForwardEmail,
+    decodeFormValue,
+    parseInboundEmail,
+    parseRawInboundEmail,
 };

--- a/api/email2email.test.js
+++ b/api/email2email.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const handler = require('./email2email');
+const {
+    buildForwardEmail,
+    parseInboundEmail,
+} = handler._test;
+
+test('parses raw RFC822 email and builds a forward payload', async () => {
+    process.env.TO_EMAIL_ADDRESS = 'forward@example.com';
+
+    const rawEmail = [
+        'Delivered-To: ychian@gmail.com',
+        'Received: by 2002:a05:612c:564e:b0:59a:5719:d59f with SMTP id p14csp3962770vqb;',
+        ' Wed, 13 May 2026 23:14:29 -0700 (PDT)',
+        'ARC-Seal: i=1; a=rsa-sha256; t=1778739269; cv=none; d=google.com;',
+        ' s=arc-20240605; b=Tskr4NylIRbza5JfXvRWeiRBzTLebxSMP6Slq4HbEc+Ge2OAiAN/LAm5U296pItfdB',
+        'Return-Path: <reservation@magia.tokyo>',
+        'Date: Thu, 14 May 2026 15:14:28 +0900',
+        'To: Josh S <ychian@gmail.com>',
+        'From: A Happy Pancake <reservation@magia.tokyo>',
+        'Subject: A Happy Pancake Changes of your account',
+        'Message-ID: <21546c257bb628a702d84e8af25dcafd@magia.tokyo>',
+        'MIME-Version: 1.0',
+        'Content-Type: text/plain; charset=UTF-8',
+        'Content-Transfer-Encoding: 8bit',
+        '',
+        '\u203bPLEASE DO NOT REPLY TO THIS EMAIL ADDRESS.',
+        '',
+        'Dear Josh S',
+        '',
+        'We acknowledge changes of your account as below.',
+        '',
+        'E-mail:  ychian@gmail.com',
+        'Password:  XzVaiyP2',
+        'Name:  Josh S',
+        '',
+        'Reservation Page',
+        'http://magia.tokyo/reserve/',
+        '',
+    ].join('\r\n');
+
+    const inboundEmail = await parseInboundEmail({
+        body: { email: Buffer.from(rawEmail, 'utf8') },
+        files: [],
+    });
+    const forwardEmail = buildForwardEmail(inboundEmail);
+
+    assert.equal(inboundEmail.fromAddress.address, 'reservation@magia.tokyo');
+    assert.equal(inboundEmail.toAddress.address, 'ychian@gmail.com');
+    assert.equal(forwardEmail.to, 'forward@example.com');
+    assert.equal(forwardEmail.from, 'ychian@gmail.com');
+    assert.equal(forwardEmail.subject, 'A Happy Pancake Changes of your account [magia.tokyo]');
+    assert.match(forwardEmail.text, /Password:\s+XzVaiyP2/);
+    assert.equal('html' in forwardEmail, false);
+});
+
+test('keeps parsed SendGrid inbound fields working', async () => {
+    process.env.TO_EMAIL_ADDRESS = 'forward@example.com';
+
+    const inboundEmail = await parseInboundEmail({
+        body: {
+            from: 'Sender <sender@example.com>',
+            to: 'Receiver <receiver@example.com>',
+            subject: 'Parsed field message',
+            text: 'Plain text body',
+            html: '<p>Plain text body</p>',
+            attachments: '0',
+        },
+        files: [],
+    });
+    const forwardEmail = buildForwardEmail(inboundEmail);
+
+    assert.equal(forwardEmail.to, 'forward@example.com');
+    assert.equal(forwardEmail.from, 'receiver@example.com');
+    assert.equal(forwardEmail.subject, 'Parsed field message [example.com]');
+    assert.equal(forwardEmail.text, 'Plain text body');
+    assert.equal(forwardEmail.html, '<p>Plain text body</p>');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,21 @@
         "axios": "^1.6.0",
         "busboy": "^1.6.0",
         "email-addresses": "^3.1.0",
+        "mailparser": "^3.9.8",
         "util": "^0.12.3"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@sendgrid/client": {
@@ -52,6 +66,41 @@
       },
       "engines": {
         "node": ">=12.*"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit/node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/asynckit": {
@@ -163,6 +212,61 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -181,6 +285,27 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
       "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.20.1",
@@ -490,6 +615,66 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -696,6 +881,66 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
+      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.8.tgz",
+      "integrity": "sha512-7jSlFGXiianVnhnb6wdutJFloD34488nrHY7r6FNqwXAhZ7YiJDYrKKTxZJ0oSrXcAPHm8YoYnh97xyGtrBQ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "9.0.5",
+        "iconv-lite": "0.7.2",
+        "libmime": "5.3.8",
+        "linkify-it": "5.0.0",
+        "nodemailer": "8.0.5",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -722,6 +967,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {
@@ -757,6 +1011,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -764,6 +1040,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -800,6 +1085,24 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -847,6 +1150,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -911,6 +1229,15 @@
     }
   },
   "dependencies": {
+    "@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "requires": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      }
+    },
     "@sendgrid/client": {
       "version": "8.1.6",
       "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
@@ -935,6 +1262,37 @@
       "requires": {
         "@sendgrid/client": "^8.1.5",
         "@sendgrid/helpers": "^8.0.0"
+      }
+    },
+    "@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "requires": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "libmime": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+          "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+          "requires": {
+            "encoding-japanese": "2.2.0",
+            "iconv-lite": "0.6.3",
+            "libbase64": "1.3.0",
+            "libqp": "2.1.1"
+          }
+        }
       }
     },
     "asynckit": {
@@ -1010,6 +1368,39 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
     "dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1024,6 +1415,16 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
       "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
+    },
+    "encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "es-abstract": {
       "version": "1.20.1",
@@ -1222,6 +1623,42 @@
         "function-bind": "^1.1.2"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "requires": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1350,6 +1787,57 @@
         "call-bind": "^1.0.2"
       }
     },
+    "leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="
+    },
+    "libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="
+    },
+    "libmime": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
+      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "requires": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="
+    },
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "mailparser": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.8.tgz",
+      "integrity": "sha512-7jSlFGXiianVnhnb6wdutJFloD34488nrHY7r6FNqwXAhZ7YiJDYrKKTxZJ0oSrXcAPHm8YoYnh97xyGtrBQ3w==",
+      "requires": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "9.0.5",
+        "iconv-lite": "0.7.2",
+        "libmime": "5.3.8",
+        "linkify-it": "5.0.0",
+        "nodemailer": "8.0.5",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
+    },
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1367,6 +1855,11 @@
       "requires": {
         "mime-db": "1.52.0"
       }
+    },
+    "nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -1389,10 +1882,29 @@
         "object-keys": "^1.1.1"
       }
     },
+    "parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "requires": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      }
+    },
+    "peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="
+    },
     "proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -1408,6 +1920,19 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "requires": {
+        "parseley": "^0.12.0"
+      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -1443,6 +1968,16 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
       }
+    },
+    "tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA=="
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "axios": "^1.6.0",
     "busboy": "^1.6.0",
     "email-addresses": "^3.1.0",
+    "mailparser": "^3.9.8",
     "util": "^0.12.3"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add raw RFC822 email parsing for inbound messages delivered as an `email` payload or non-multipart body.
- Preserve the existing SendGrid parsed-field forwarding path.
- Return explicit errors for invalid inbound addresses and failed processing instead of leaving responses unfinished.
- Add Node test coverage for raw email forwarding and parsed SendGrid fields.

## Testing
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac4102e1-5fe9-4cd7-b085-67e752e80984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac4102e1-5fe9-4cd7-b085-67e752e80984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

