### PR TITLE
Fix Notion SDK v5 compatibility for receipt processing

### DIFF
--- a/lib/notionExpense.js
+++ b/lib/notionExpense.js
@@ -16,6 +16,7 @@ class NotionExpenseError extends Error {
 }
 
 let notionClient;
+const dataSourceIdCache = new Map();
 
 function getNotionClient() {
     if (!process.env.NOTION_API_KEY) {
@@ -41,15 +42,34 @@ function getDatabaseId(key) {
     return (envKey && process.env[envKey]) || DEFAULT_DATABASE_IDS[key];
 }
 
+async function getDataSourceId(databaseKey) {
+    const databaseId = getDatabaseId(databaseKey);
+    if (dataSourceIdCache.has(databaseId)) {
+        return dataSourceIdCache.get(databaseId);
+    }
+
+    const notion = getNotionClient();
+    const database = await notion.databases.retrieve({ database_id: databaseId });
+    const dataSourceId = database.data_sources?.[0]?.id;
+
+    if (!dataSourceId) {
+        throw new NotionExpenseError(`No data source found for database ${databaseKey}`);
+    }
+
+    dataSourceIdCache.set(databaseId, dataSourceId);
+    return dataSourceId;
+}
+
 function monthlyExpenseName(date) {
     const [year, month] = date.split('-');
     return `${year} ${month}`;
 }
 
-async function queryDatabase(databaseId, filter) {
+async function queryDatabase(databaseKey, filter) {
     const notion = getNotionClient();
-    const response = await notion.databases.query({
-        database_id: databaseId,
+    const dataSourceId = await getDataSourceId(databaseKey);
+    const response = await notion.dataSources.query({
+        data_source_id: dataSourceId,
         filter,
         page_size: 5,
     });
@@ -58,7 +78,7 @@ async function queryDatabase(databaseId, filter) {
 }
 
 async function findWalletByCardLast4(cardLast4) {
-    const results = await queryDatabase(getDatabaseId('wallet'), {
+    const results = await queryDatabase('wallet', {
         property: 'Name',
         title: { ends_with: ` - ${cardLast4}` },
     });
@@ -76,7 +96,7 @@ async function findWalletByCardLast4(cardLast4) {
 }
 
 async function findDailyExpensePage(date) {
-    const results = await queryDatabase(getDatabaseId('dailyExpense'), {
+    const results = await queryDatabase('dailyExpense', {
         property: 'Date',
         date: { equals: date },
     });
@@ -86,7 +106,7 @@ async function findDailyExpensePage(date) {
 
 async function findMonthlyExpensePage(date) {
     const name = monthlyExpenseName(date);
-    const results = await queryDatabase(getDatabaseId('monthlyExpense'), {
+    const results = await queryDatabase('monthlyExpense', {
         property: 'Name',
         title: { equals: name },
     });
@@ -96,8 +116,9 @@ async function findMonthlyExpensePage(date) {
 
 async function createDailyExpensePage(date) {
     const notion = getNotionClient();
+    const dataSourceId = await getDataSourceId('dailyExpense');
     const page = await notion.pages.create({
-        parent: { database_id: getDatabaseId('dailyExpense') },
+        parent: { data_source_id: dataSourceId },
         properties: {
             Name: {
                 title: [{ text: { content: date } }],
@@ -114,8 +135,9 @@ async function createDailyExpensePage(date) {
 async function createMonthlyExpensePage(date) {
     const notion = getNotionClient();
     const name = monthlyExpenseName(date);
+    const dataSourceId = await getDataSourceId('monthlyExpense');
     const page = await notion.pages.create({
-        parent: { database_id: getDatabaseId('monthlyExpense') },
+        parent: { data_source_id: dataSourceId },
         properties: {
             Name: {
                 title: [{ text: { content: name } }],
@@ -167,7 +189,7 @@ function buildDedupFilter(expense) {
 }
 
 async function findDuplicateExpense(expense) {
-    const results = await queryDatabase(getDatabaseId('expenses'), buildDedupFilter(expense));
+    const results = await queryDatabase('expenses', buildDedupFilter(expense));
     return results[0] || null;
 }
 
@@ -224,8 +246,9 @@ async function createExpenseIfNew(expense, walletId, periodIds) {
     }
 
     const notion = getNotionClient();
+    const dataSourceId = await getDataSourceId('expenses');
     const page = await notion.pages.create({
-        parent: { database_id: getDatabaseId('expenses') },
+        parent: { data_source_id: dataSourceId },
         properties: buildExpenseProperties(expense, walletId, periodIds),
     });
 


### PR DESCRIPTION
## Summary
- Fixes `TypeError: notion.databases.query is not a function` when processing BOC receipt emails in production
- Updates `lib/notionExpense.js` to use Notion API 2025-09-03 patterns required by `@notionhq/client` v5: `dataSources.query` for lookups and `data_source_id` parent for page creation
- Resolves data source IDs via `databases.retrieve` with per-database caching to avoid extra API calls

## Test plan
- [x] `node --test lib/receipt.test.js` passes locally
- [ ] Deploy to Vercel and forward a BOC receipt to `receipt@littleplan.com`
- [ ] Verify Notion Expense row is created with correct wallet, amount, and period relations
- [ ] Re-send same receipt and confirm duplicate detection works


Made with [Cursor](https://cursor.com)