### PR TITLE
Add Notion icons to newly created expense pages

### DIFF
--- a/lib/expenseIcon.js
+++ b/lib/expenseIcon.js
@@ -1,0 +1,46 @@
+const { CATEGORY_IDS } = require('./merchantRules');
+
+function notionIcon(name, color = 'gray') {
+    return {
+        type: 'icon',
+        icon: { name, color },
+    };
+}
+
+const EXPENSE_ICONS_BY_NAME = {
+    'Gym - LCSD': notionIcon('dumbbell'),
+    ParkNShop: notionIcon('banana'),
+    Citybus: notionIcon('bus'),
+    MTR: notionIcon('train'),
+    Taobao: notionIcon('shopping-bag'),
+};
+
+const EXPENSE_ICONS_BY_CATEGORY = {
+    [CATEGORY_IDS.sports]: notionIcon('dumbbell'),
+    [CATEGORY_IDS.grocery]: notionIcon('banana'),
+    [CATEGORY_IDS.transport]: notionIcon('bus'),
+    [CATEGORY_IDS.shopping]: notionIcon('shopping-bag'),
+};
+
+const DAILY_EXPENSE_ICON = notionIcon('calendar-day');
+const MONTHLY_EXPENSE_ICON = notionIcon('calendar');
+const DEFAULT_EXPENSE_ICON = notionIcon('credit-card');
+
+function resolveExpenseIcon(expense) {
+    if (expense.name && EXPENSE_ICONS_BY_NAME[expense.name]) {
+        return EXPENSE_ICONS_BY_NAME[expense.name];
+    }
+
+    if (expense.categoryId && EXPENSE_ICONS_BY_CATEGORY[expense.categoryId]) {
+        return EXPENSE_ICONS_BY_CATEGORY[expense.categoryId];
+    }
+
+    return DEFAULT_EXPENSE_ICON;
+}
+
+module.exports = {
+    resolveExpenseIcon,
+    DAILY_EXPENSE_ICON,
+    MONTHLY_EXPENSE_ICON,
+    DEFAULT_EXPENSE_ICON,
+};

--- a/lib/notionExpense.js
+++ b/lib/notionExpense.js
@@ -1,4 +1,5 @@
 const { Client } = require('@notionhq/client');
+const { resolveExpenseIcon, DAILY_EXPENSE_ICON, MONTHLY_EXPENSE_ICON } = require('./expenseIcon');
 
 const DEFAULT_DATABASE_IDS = {
     expenses: '8c07d787-86bd-4643-8d68-92b85f3b7a04',
@@ -156,6 +157,7 @@ async function createDailyExpensePage(date) {
     const dataSourceId = await getDataSourceId('dailyExpense');
     const page = await notion.pages.create({
         parent: { data_source_id: dataSourceId },
+        icon: DAILY_EXPENSE_ICON,
         properties: {
             Name: {
                 title: [{ text: { content: date } }],
@@ -175,6 +177,7 @@ async function createMonthlyExpensePage(date) {
     const dataSourceId = await getDataSourceId('monthlyExpense');
     const page = await notion.pages.create({
         parent: { data_source_id: dataSourceId },
+        icon: MONTHLY_EXPENSE_ICON,
         properties: {
             Name: {
                 title: [{ text: { content: name } }],
@@ -286,6 +289,7 @@ async function createExpenseIfNew(expense, walletId, periodIds) {
     const dataSourceId = await getDataSourceId('expenses');
     const page = await notion.pages.create({
         parent: { data_source_id: dataSourceId },
+        icon: resolveExpenseIcon(expense),
         properties: buildExpenseProperties(expense, walletId, periodIds),
     });
 

--- a/lib/receipt.test.js
+++ b/lib/receipt.test.js
@@ -6,6 +6,7 @@ const { parseBocTransaction } = require('./parseBocTransaction');
 const { applyMerchantRules } = require('./merchantRules');
 const { formatExchangeRateText } = require('./exchangeRate');
 const { monthlyExpenseName, resolveWalletLookup } = require('./notionExpense');
+const { resolveExpenseIcon } = require('./expenseIcon');
 const {
     canProcessReceiptEmail,
     isAuthorizedReceiptSender,
@@ -118,4 +119,11 @@ test('allows receipt processing only from the authorized sender to receipt addre
     assert.equal(canProcessReceiptEmail(authorizedFrom, receiptTo), true);
     assert.equal(canProcessReceiptEmail(unauthorizedFrom, receiptTo), false);
     assert.equal(canProcessReceiptEmail(authorizedFrom, otherTo), false);
+});
+
+test('resolves Notion icons for known merchants and categories', () => {
+    assert.equal(resolveExpenseIcon({ name: 'MTR', categoryId: null }).icon.name, 'train');
+    assert.equal(resolveExpenseIcon({ name: 'Citybus', categoryId: null }).icon.name, 'bus');
+    assert.equal(resolveExpenseIcon({ name: 'ParkNShop', categoryId: null }).icon.name, 'banana');
+    assert.equal(resolveExpenseIcon({ name: 'Random Merchant', categoryId: null }).icon.name, 'credit-card');
 });


### PR DESCRIPTION
## Summary
- Adds `lib/expenseIcon.js` to resolve Notion native icons for new expense rows based on merchant name or category
- Sets icons when creating Expenses, Daily Expense, and Monthly Expense pages

### Expense icon mapping
| Merchant / category | Icon |
|---|---|
| Gym - LCSD / Sports | dumbbell |
| ParkNShop / Grocery | banana |
| Citybus / Transport | bus |
| MTR | train |
| Taobao / Shopping | shopping-bag |
| Unknown merchants | credit-card |

### Period pages
- Daily Expense → `calendar-day`
- Monthly Expense → `calendar`

## Test plan
- [x] `node --test lib/receipt.test.js` passes locally
- [ ] Forward a receipt and confirm the new Expense row shows the expected icon
- [ ] Test a transaction on a new date and confirm Daily/Monthly Expense pages get calendar icons when auto-created


Made with [Cursor](https://cursor.com)