### PR TITLE
Skip merchant rename rules for card ending 1110

### DIFF
--- a/lib/merchantRules.js
+++ b/lib/merchantRules.js
@@ -5,6 +5,8 @@ const CATEGORY_IDS = {
     shopping: '94414e58-b0b0-42e0-aa40-f6fe1f700ed8',
 };
 
+const EXACT_MERCHANT_CARD_LAST4 = new Set(['1110']);
+
 const RULES = [
     { keywords: ['LCSD', 'SMARTPLAY'], name: 'Gym - LCSD', categoryId: CATEGORY_IDS.sports },
     { keywords: ['PARKNSHOP'], name: 'ParkNShop', categoryId: CATEGORY_IDS.grocery },
@@ -13,8 +15,14 @@ const RULES = [
     { keywords: ['TAOBAO'], name: 'Taobao', categoryId: CATEGORY_IDS.shopping },
 ];
 
-function applyMerchantRules(rawMerchant) {
-    const upper = String(rawMerchant || '').toUpperCase();
+function applyMerchantRules(rawMerchant, cardLast4) {
+    const name = String(rawMerchant || '').trim();
+
+    if (cardLast4 && EXACT_MERCHANT_CARD_LAST4.has(cardLast4)) {
+        return { name, categoryId: null };
+    }
+
+    const upper = name.toUpperCase();
 
     for (const rule of RULES) {
         if (rule.keywords.some((keyword) => upper.includes(keyword))) {
@@ -22,11 +30,12 @@ function applyMerchantRules(rawMerchant) {
         }
     }
 
-    return { name: String(rawMerchant || '').trim(), categoryId: null };
+    return { name, categoryId: null };
 }
 
 module.exports = {
     applyMerchantRules,
     CATEGORY_IDS,
     RULES,
+    EXACT_MERCHANT_CARD_LAST4,
 };

--- a/lib/receipt.test.js
+++ b/lib/receipt.test.js
@@ -90,6 +90,24 @@ test('merchant rules rename and categorize known merchants', () => {
     });
 });
 
+test('card ending 1110 keeps exact merchant name without rules', () => {
+    assert.deepEqual(applyMerchantRules('TAOBAO MERCHANT', '1110'), {
+        name: 'TAOBAO MERCHANT',
+        categoryId: null,
+    });
+
+    assert.deepEqual(applyMerchantRules('AlipayHK*PARKnSHOP H', '1110'), {
+        name: 'AlipayHK*PARKnSHOP H',
+        categoryId: null,
+    });
+
+    const transaction = parseBocTransaction(CNY_EMAIL);
+    assert.deepEqual(applyMerchantRules(transaction.merchant, transaction.cardLast4), {
+        name: 'TAOBAO MERCHANT',
+        categoryId: null,
+    });
+});
+
 test('formats exchange rate text like existing Notion entries', () => {
     assert.equal(formatExchangeRateText('CNY', 1.1597), '1CNY=1.15970HKD');
 });

--- a/lib/receiptHandler.js
+++ b/lib/receiptHandler.js
@@ -29,7 +29,7 @@ function canProcessReceiptEmail(fromAddress, toAddress) {
 async function processReceiptEmail(inboundEmail) {
     const bodyText = inboundEmail.text || stripHtml(inboundEmail.html);
     const transaction = parseBocTransaction(bodyText);
-    const { name, categoryId } = applyMerchantRules(transaction.merchant);
+    const { name, categoryId } = applyMerchantRules(transaction.merchant, transaction.cardLast4);
     const amounts = await resolveAmounts(transaction);
     const walletId = await findWalletForTransaction(transaction);
     const periodIds = await findOrCreatePeriodExpenses(transaction.date);


### PR DESCRIPTION
## Summary
- Card ending `1110` bypasses merchant rename and category rules
- Uses the exact merchant name from the BOC email and leaves Category blank
- Other cards continue to use existing keyword-based merchant rules

## Test plan
- [x] `node --test lib/receipt.test.js` passes locally
- [x] Forward a receipt from card `1110` with a known merchant keyword (e.g. TAOBAO) and confirm Notion Name stays as the raw merchant text
- [x] Forward a receipt from another card and confirm rename rules still apply


Made with [Cursor](https://cursor.com)